### PR TITLE
fix stack overflow bug

### DIFF
--- a/llvm/lib/Transforms/Obfuscation/MBAUtils.cpp
+++ b/llvm/lib/Transforms/Obfuscation/MBAUtils.cpp
@@ -90,9 +90,7 @@ Value *llvm::insertLinearMBA(int64_t *params, Instruction *insertBefore) {
         x = builder.CreateLoad(xPtr);
         y = builder.CreateLoad(yPtr);
     }
-    Value *mbaExpr = builder.CreateAlloca(x->getType());
-    builder.CreateStore(ConstantInt::get(x->getType(), 0), mbaExpr);
-    mbaExpr = builder.CreateLoad(mbaExpr);
+    Value *mbaExpr = ConstantInt::get(x->getType(), 0);
     Value *boolExpr, *term;
     for (int i = 0; i < 15; i++) {
         if (!params[i])


### PR DESCRIPTION
When I used MBA Obfuscator to run the mbedtls 3.4.0 benchmark, it actually crashed.

So I went through the assembly, only to find that each instruction substitution will raise the stack pointer.
If obfuscated opeartions are called many times in the same function, the stack will overflow, causing segmentation fault.

PoC: 
``` c
#include <stdio.h>
#include <stdint.h>

uint64_t func(const uint64_t t, const uint64_t n){
    uint64_t res = t;

    /*
        never mind, just a few casual calculations
    */
    for(uint64_t i = 0; i < n; i++){  
        res = ((114514 + res) >> 1) + ((1919810 + res) << 1);
        res = (res + 0x24) * 24;
    }
    return res;
}

int main(){
    printf("result is: 0x%llx", func(1, 0x10000000));
}
```

compilation args: `clang test.c -mllvm -mba -mllvm -mba-prob=50 -o test_obf`
