### PR TITLE
Fix two GlobalsEncryption pass bugs

### DIFF
--- a/llvm/lib/Transforms/Obfuscation/GlobalsEncryption.cpp
+++ b/llvm/lib/Transforms/Obfuscation/GlobalsEncryption.cpp
@@ -28,6 +28,9 @@ bool GlobalsEncryption::runOnModule(Module &M) {
     INIT_CONTEXT(M);
     vector<GlobalVariable *> GVs;
     for (GlobalVariable &GV : M.getGlobalList()) {
+        // only process non llvm-generated IRs
+        if(GV.getName().contains("llvm"))
+            continue;
         GVs.push_back(&GV);
     }
     for (int i = 0; i < ObfuTimes; i++) {
@@ -38,9 +41,7 @@ bool GlobalsEncryption::runOnModule(Module &M) {
             continue;
         }
         if (GV->hasInitializer() && GV->getInitializer() &&
-            (GV->getName().contains(".str") || !OnlyStr)
-            // Do not encrypt globals having a section named "llvm.metadata"
-            && !GV->getSection().equals("llvm.metadata")) {
+            (GV->getName().contains(".str") || !OnlyStr)) {
             Constant *initializer = GV->getInitializer();
             ConstantInt *intData = dyn_cast<ConstantInt>(initializer);
             ConstantDataArray *arrData = dyn_cast<ConstantDataArray>(initializer);

--- a/llvm/lib/Transforms/Obfuscation/GlobalsEncryption.cpp
+++ b/llvm/lib/Transforms/Obfuscation/GlobalsEncryption.cpp
@@ -35,11 +35,16 @@ bool GlobalsEncryption::runOnModule(Module &M) {
     }
     for (int i = 0; i < ObfuTimes; i++) {
         for (GlobalVariable *GV : GVs) {
-        // Only encrypt globals of integer and array
-        if (!GV->getValueType()->isIntegerTy() &&
-            !GV->getValueType()->isArrayTy()) {
-            continue;
-        }
+            if(GV->getValueType()->isArrayTy()){ // the value can be array
+                ArrayType *ArrTy = dyn_cast<ArrayType>(GV->getValueType());
+                if(!ArrTy->getElementType()->isIntegerTy()){  // but the array must be integerty
+                    continue;
+                }
+            }
+            else if (!GV->getValueType()->isIntegerTy()){  // or, the value must be integerty
+                continue;
+            }
+
         if (GV->hasInitializer() && GV->getInitializer() &&
             (GV->getName().contains(".str") || !OnlyStr)) {
             Constant *initializer = GV->getInitializer();


### PR DESCRIPTION
Fix bugs: 
1. LLVM pass crashes during compilation due to modification of LLVM's built-in global variables. #55 
2. LLVM pass crashes during processing double variables. #58 